### PR TITLE
Fix hex encoding

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -208,6 +208,7 @@ func (d *mySQL) excludeGeneratedColumns(table, createTable string) string {
 }
 
 func (d *mySQL) isColumnBinary(table, columnName string) bool {
+	columnName = strings.Trim(columnName, "`")
 	if val, ok := d.mapBins[table]; ok {
 		for _, b := range val {
 			if b == columnName {


### PR DESCRIPTION
`d.mapBins` contains escaped columns. The given argument columnName is not escaped. So this will be never return true