### PR TITLE
fix: table ignoring with different cases

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -94,11 +94,11 @@ func (d *mySQL) SetFilterMap(noData, ignore []string) error {
 		return err
 	}
 	for _, table := range d.listTables(t, noData) {
-		d.filterMap[table] = NoDataMapPlacement
+		d.filterMap[strings.ToLower(table)] = NoDataMapPlacement
 	}
 
 	for _, table := range d.listTables(t, ignore) {
-		d.filterMap[table] = IgnoreMapPlacement
+		d.filterMap[strings.ToLower(table)] = IgnoreMapPlacement
 	}
 
 	return nil


### PR DESCRIPTION
I use this as a library in my cli. One user reported that isn't possible to skip tables. So here is the fix

Issue: https://github.com/FriendsOfShopware/shopware-cli/issues/52

SetFilterMap wrote the normal table name and the Dump tried to access it with lowercase