### PR TITLE
fix: improve trigger escaping

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -597,10 +597,13 @@ func (d *mySQL) dumpTriggers(w io.Writer) error {
 		}
 
 		fmt.Fprintf(w, "\n--\n-- Trigger `%s`\n--\n\n", trigger)
+		fmt.Fprintln(w, "DELIMITER //")
 
 		if _, err := w.Write([]byte(ddl)); err != nil {
 			return err
 		}
+		fmt.Fprintln(w, "//")
+		fmt.Fprintln(w, "DELIMITER ;")
 	}
 
 	return nil

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -559,6 +559,14 @@ func Test_mySQL_dumpsTriggers(t *testing.T) {
 	if !strings.Contains(b.String(), "CREATE DEFINER=`root`@`%` TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH ROW SET @sum = @sum + NEW.amount;") {
 		t.Error("Trigger not dumped")
 	}
+
+	if !strings.Contains(b.String(), "DELIMITER //") {
+		t.Error("Trigger escaping is missing")
+	}
+
+	if !strings.Contains(b.String(), "DELIMITER ;") {
+		t.Error("Trigger escaping reset is missing")
+	}
 }
 
 func Test_mySQL_dumpsTriggersIgnoresDefiners(t *testing.T) {


### PR DESCRIPTION
fixes #45 

Generated looks now so:

```
--
-- Trigger `upd_check`
--

DELIMITER //
CREATE DEFINER=`root`@`localhost` TRIGGER `upd_check` BEFORE UPDATE ON `account` FOR EACH ROW BEGIN
           IF NEW.amount < 0 THEN
               SET NEW.amount = 0;
           ELSEIF NEW.amount > 100 THEN
               SET NEW.amount = 100;
           END IF;
       END;
//
DELIMITER ;

--
-- Trigger `upd_check2`
--

DELIMITER //
CREATE DEFINER=`root`@`localhost` TRIGGER `upd_check2` BEFORE UPDATE ON `account` FOR EACH ROW BEGIN
           IF NEW.amount < 0 THEN
               SET NEW.amount = 0;
           ELSEIF NEW.amount > 100 THEN
               SET NEW.amount = 100;
           END IF;
       END;
//
DELIMITER ;
```

Tested dumping and importing works fine