### PR TITLE
fix redundant sql statements

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -152,8 +152,10 @@ func (d *mySQL) Dump(w io.Writer) error {
 		}
 
 		if _, err = fmt.Fprintln(w, dump); err != nil {
-			d.log.Error(err.Error())
+			return err
 		}
+
+		dump = ""
 	}
 
 	if d.singleTransaction {


### PR DESCRIPTION
The variable `dump` is only cleared conditionally if the table is not empty and not after every time its contents are flushed.

This causes redundant SQL statements to be written to the output, which becomes especially clear if multiple empty tables are iterated consecutively. This in turn causes the dump file to become unnecessarily large.