### PR TITLE
Run exports in goroutines

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,6 +145,10 @@ var rootCmd = &cobra.Command{
 			opt = append(opt, database.OptionValue("skip-definer", ""))
 		}
 
+		if parallel {
+			opt = append(opt, database.OptionValue("parallel", ""))
+		}
+
 		dumper, err := database.NewMySQLDumper(db, logger, service, opt...)
 		if err != nil {
 			logger.Fatal(
@@ -222,6 +226,7 @@ var (
 	dumpTrigger       bool
 	skipDefiner       bool
 	triggerDelimiter  string
+	parallel          bool
 )
 
 func Execute() error {
@@ -376,5 +381,12 @@ func init() {
 		"trigger-delimiter",
 		"",
 		"define the char to delimit triggers",
+	)
+
+	rootCmd.PersistentFlags().BoolVar(
+		&parallel,
+		"parallel",
+		false,
+		"run exports in parallel",
 	)
 }

--- a/core/slice.go
+++ b/core/slice.go
@@ -10,3 +10,12 @@ func AppendIfNotExists(slice []string, add string) []string {
 
 	return append(slice, add)
 }
+
+func InSlice(slice []string, needle string) bool {
+	for _, a := range slice {
+		if a == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/slice_test.go
+++ b/core/slice_test.go
@@ -16,3 +16,12 @@ func TestAppendIfMissing(t *testing.T) {
 
 	assert.Equal(t, []string{"exists", "not_exists"}, slice)
 }
+
+func TestInSlice(t *testing.T) {
+	slice := []string{
+		"a", "b", "c", "d",
+	}
+
+	assert.True(t, InSlice(slice, "c"))
+	assert.False(t, InSlice(slice, "f"))
+}

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -42,6 +42,7 @@ type mySQL struct {
 	dumpTrigger         bool
 	skipDefiner         bool
 	triggerDelimiter    string
+	parallel            bool
 }
 
 const (

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -181,7 +181,7 @@ func (d *mySQL) Dump(w io.Writer) error {
 			readResults := make(chan string, 100)
 			done := make(chan struct{}, 1)
 
-			go writeToTempFile(ctx, tempDir, table, index, readResults, errors, writeResults, done, writingSemaphore)
+			go d.writeToTempFile(ctx, tempDir, table, index, readResults, errors, writeResults, done, writingSemaphore)
 
 			var dump string
 			var binaryColumns []string
@@ -718,7 +718,7 @@ func (d *mySQL) getTrigger(ctx context.Context, conn *mySQLConn, triggerName str
 	return ddl + ";\n", nil
 }
 
-func writeToTempFile(ctx context.Context, tempDir string, table string, tableIndex int, source <-chan string, errors chan<- error, results chan<- writeResult, done <-chan struct{}, writingSemaphore chan struct{}) {
+func (d *mySQL) writeToTempFile(ctx context.Context, tempDir string, table string, tableIndex int, source <-chan string, errors chan<- error, results chan<- writeResult, done <-chan struct{}, writingSemaphore chan struct{}) {
 	writingSemaphore <- struct{}{}
 	defer func() {
 		<-writingSemaphore

--- a/database/mysql_conn.go
+++ b/database/mysql_conn.go
@@ -1,0 +1,79 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+)
+
+type mySQLConn struct {
+	conn              *sql.Conn
+	openTx            *sql.Tx
+	singleTransaction bool
+}
+
+func newMySQLConn(ctx context.Context, db *sql.DB, singleTransaction bool) (*mySQLConn, error) {
+	dedicatedConn, err := db.Conn(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &mySQLConn{
+		conn:              dedicatedConn,
+		singleTransaction: singleTransaction,
+	}, nil
+}
+
+func (c *mySQLConn) Close() error {
+	return c.conn.Close()
+}
+
+func (c *mySQLConn) Commit() error {
+	if c.openTx == nil {
+		return nil
+	}
+
+	return c.openTx.Commit()
+}
+
+func (c *mySQLConn) getTransaction(ctx context.Context) (*sql.Tx, error) {
+	if c.openTx != nil {
+		return c.openTx, nil
+	}
+
+	var err error
+	c.openTx, err = c.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.openTx, nil
+}
+
+func (c *mySQLConn) useTransactionOrDBQueryRow(ctx context.Context, query string) (*sql.Row, error) {
+	if c.singleTransaction {
+		tx, err := c.getTransaction(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return tx.QueryRowContext(ctx, query), nil
+	}
+
+	return c.conn.QueryRowContext(ctx, query), nil
+}
+
+func (c *mySQLConn) useTransactionOrDBExec(ctx context.Context, query string) (sql.Result, error) {
+	if c.singleTransaction {
+		tx, err := c.getTransaction(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return tx.ExecContext(ctx, query)
+	}
+
+	return c.conn.ExecContext(ctx, query)
+}

--- a/database/option.go
+++ b/database/option.go
@@ -42,6 +42,8 @@ func parseMysqlOptions(m *mySQL, options []Option) error {
 			m.extendedInsertLimit = i
 		case "trigger-delimiter":
 			m.triggerDelimiter = v.value
+		case "parallel":
+			m.parallel = true
 		default:
 			return errors.New("unknown option")
 		}

--- a/database/option_test.go
+++ b/database/option_test.go
@@ -71,6 +71,17 @@ func TestOption(t *testing.T) {
 			"passing an empty value",
 			true,
 		},
+		{
+			[]Option{
+				OptionValue("parallel", ""),
+			},
+			&mySQL{},
+			&mySQL{
+				parallel: true,
+			},
+			"test parallel option",
+			false,
+		},
 	}
 	for _, tt := range testCases {
 		err := parseMysqlOptions(tt.mysql, tt.options)


### PR DESCRIPTION
### Concurrent Dumping Implementation
As part of learning Go, I refactored the dumping process to make it concurrent.

Each table (unless explicitly ignored) is now processed in its own goroutine. Within each of these, another goroutine handles writing the data to disk via a channel. This data is first written to a temporary file.

Once all tables are processed, their contents are copied to the final output in the original order. Triggers, if present, are appended afterward.

### Summary of Changes

- Refactored to remove global variables related to binary and generated columns.
- Established a dedicated MySQL connection per data-reading goroutine (also acts as a counting semaphore).
- Introduced context cancellation support.
- Added a --parallel CLI option to control concurrency.
- Updated tests to reflect the changes.

Validation
Compared resulting dump files before and after the changes using:

`git diff --no-index --ignore-blank-lines old.sql new.sql`

No differences observed except for blank lines.

**Feedback is welcome!**

