### PR TITLE
Support dumping views

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,27 +54,28 @@ please refer to faker documentation [here](https://pkg.go.dev/github.com/jaswdr/
 
 ## Available Flags (all are optional)
 
-| Flag (short)         | Description                                                                                 | Type   |
-|----------------------|---------------------------------------------------------------------------------------------|--------|
-| --host (-h)          | your MySQL host, default `127.0.0.1`                                                        | string |
-| --user (-u)          | your user to authenticate in mysql, no default                                              | string |
-| --password (-p)      | password to authenticate in mysql, no default                                               | string |
-| --port (-P)          | port to your mysql installation, default `3306`                                             | string |
-| --config (-c)        | path to your go-mad config file, example below                                              | string |
-| --output (-o)        | path to the intended output file, default STDOUT                                            | string |
-| --char-set           | uses SET NAMES command with provided charset, default utf8                                  | string |
-| --trigger-definer    | changes trigger delimiter to the string you pass, default is `';'`                          | string |
-| --insert-into-limit  | defines limit to be used with each insert statement, cannot use with --quick, default `100` | int    |
-| --debug (-v)         | turns on verbose mode if passed                                                             | bool   |
-| --quiet (-q)         | disables log output if passed                                                               | bool   |
-| --skip-lock-tables   | skips locking mysql tables when dumping                                                     | bool   |
-| --single-transaction | does the dump within a single transaction by issuing a BEGIN Command                        | bool   |
-| --quick              | dump writes row by row as opposed to using extended inserts                                 | bool   |
-| --add-locks          | add write lock statements to the dump                                                       | bool   |
-| --hex-encode         | performs hex encoding and respective decode statement for binary values                     | bool   |
-| --ignore-generated   | strips generated columns from create statements                                             | bool   |
-| --dump-trigger       | dumps triggers from database                                                                | bool   |
-| --skip-definer       | skips definer of triggers dumps (used in conjuntion with `--dump-trigger`)                  | bool   |
+| Flag (short)         | Description                                                                                  | Type   |
+|----------------------|----------------------------------------------------------------------------------------------|--------|
+| --host (-h)          | your MySQL host, default `127.0.0.1`                                                         | string |
+| --user (-u)          | your user to authenticate in mysql, no default                                               | string |
+| --password (-p)      | password to authenticate in mysql, no default                                                | string |
+| --port (-P)          | port to your mysql installation, default `3306`                                              | string |
+| --config (-c)        | path to your go-mad config file, example below                                               | string |
+| --output (-o)        | path to the intended output file, default STDOUT                                             | string |
+| --char-set           | uses SET NAMES command with provided charset, default utf8                                   | string |
+| --trigger-definer    | changes trigger delimiter to the string you pass, default is `';'`                           | string |
+| --insert-into-limit  | defines limit to be used with each insert statement, cannot use with --quick, default `100`  | int    |
+| --debug (-v)         | turns on verbose mode if passed                                                              | bool   |
+| --quiet (-q)         | disables log output if passed                                                                | bool   |
+| --skip-lock-tables   | skips locking mysql tables when dumping                                                      | bool   |
+| --single-transaction | does the dump within a single transaction by issuing a BEGIN Command                         | bool   |
+| --quick              | dump writes row by row as opposed to using extended inserts                                  | bool   |
+| --add-locks          | add write lock statements to the dump                                                        | bool   |
+| --hex-encode         | performs hex encoding and respective decode statement for binary values                      | bool   |
+| --ignore-generated   | strips generated columns from create statements                                              | bool   |
+| --dump-trigger       | dumps triggers from database                                                                 | bool   |
+| --dump-views         | dumps views from database                                                                    | bool   |
+| --skip-definer       | skips definer of triggers dumps (used in conjuntion with `--dump-trigger` or `--dump-views`) | bool   |
 
 ## Configuration Example
 ```yaml

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,10 @@ var rootCmd = &cobra.Command{
 			opt = append(opt, database.OptionValue("dump-trigger", ""))
 		}
 
+		if dumpViews {
+			opt = append(opt, database.OptionValue("dump-views", ""))
+		}
+
 		if skipDefiner {
 			opt = append(opt, database.OptionValue("skip-definer", ""))
 		}
@@ -220,6 +224,7 @@ var (
 	getVersion        bool
 	insertIntoLimit   string
 	dumpTrigger       bool
+	dumpViews         bool
 	skipDefiner       bool
 	triggerDelimiter  string
 )
@@ -362,6 +367,13 @@ func init() {
 		"dump-trigger",
 		false,
 		"dump triggers",
+	)
+
+	rootCmd.PersistentFlags().BoolVar(
+		&dumpViews,
+		"dump-views",
+		false,
+		"dump views",
 	)
 
 	rootCmd.PersistentFlags().BoolVar(

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -42,6 +42,7 @@ type mySQL struct {
 	shouldHexBins       bool
 	ignoreGenerated     bool
 	dumpTrigger         bool
+	dumpViews           bool
 	skipDefiner         bool
 	triggerDelimiter    string
 }
@@ -73,6 +74,7 @@ func NewMySQLDumper(db *sql.DB, logger *zap.Logger, randomizerService generator.
 		mapExclusionColumns: make(map[string][]string),
 		shouldHexBins:       false,
 		ignoreGenerated:     false,
+		dumpViews:           false,
 		dumpTrigger:         false,
 		skipDefiner:         false,
 		triggerDelimiter:    "",
@@ -101,11 +103,21 @@ func (d *mySQL) SetFilterMap(noData, ignore []string) error {
 	if err != nil {
 		return err
 	}
+
+	v, err := d.getViews()
+	if err != nil {
+		return err
+	}
+
 	for _, table := range d.listTables(t, noData) {
 		d.filterMap[strings.ToLower(table)] = NoDataMapPlacement
 	}
 
 	for _, table := range d.listTables(t, ignore) {
+		d.filterMap[strings.ToLower(table)] = IgnoreMapPlacement
+	}
+
+	for _, table := range d.listViews(v, ignore) {
 		d.filterMap[strings.ToLower(table)] = IgnoreMapPlacement
 	}
 
@@ -169,6 +181,32 @@ func (d *mySQL) Dump(w io.Writer) error {
 	}
 
 	_, err = fmt.Fprintf(w, "SET FOREIGN_KEY_CHECKS = 1;\n")
+
+	if d.dumpViews {
+		views, err := d.getViews()
+		if err != nil {
+			return err
+		}
+
+		for _, view := range views {
+			if d.filterMap[strings.ToLower(view)] == IgnoreMapPlacement {
+				continue
+			}
+
+			tmp, err = d.getCreateViewStatement(view)
+			if err != nil {
+				return err
+			}
+
+			dump += tmp
+
+			if _, err = fmt.Fprintln(w, dump); err != nil {
+				return err
+			}
+
+			dump = ""
+		}
+	}
 
 	if d.dumpTrigger {
 		if err := d.dumpTriggers(w); err != nil {
@@ -343,6 +381,55 @@ func (d *mySQL) getTables() ([]string, error) {
 	}
 
 	return tables, nil
+}
+
+func (d *mySQL) listViews(views, globs []string) []string {
+	var globbed []string
+
+	for _, query := range globs {
+		g := glob.MustCompile(query)
+
+		for _, view := range views {
+			if g.Match(view) {
+				globbed = core.AppendIfNotExists(globbed, view)
+			}
+		}
+	}
+
+	return globbed
+}
+
+func (d *mySQL) getViews() ([]string, error) {
+	views := make([]string, 0)
+
+	rows, err := d.db.Query("SHOW FULL TABLES")
+	if a := d.evaluateErrors(err, rows); a != nil {
+		return views, a
+	}
+
+	defer func(rows *sql.Rows) {
+		dErr := rows.Close()
+		if dErr != nil {
+			d.log.Error(
+				dErr.Error(),
+				zap.String("internal", "failed to close rows while getting views"),
+			)
+		}
+	}(rows)
+
+	for rows.Next() {
+		var tableName, tableType string
+
+		if dErr := rows.Scan(&tableName, &tableType); dErr != nil {
+			return views, dErr
+		}
+
+		if tableType == "VIEW" {
+			views = append(views, tableName)
+		}
+	}
+
+	return views, nil
 }
 
 func (d *mySQL) dumpTableData(w io.Writer, table string) error {
@@ -546,6 +633,22 @@ func (d *mySQL) getCreateTableStatement(table string) (string, error) {
 	if err := row.Scan(&tname, &ddl); err != nil {
 		return "", err
 	}
+	s += fmt.Sprintf("%s;\n", ddl)
+	return s, nil
+}
+
+func (d *mySQL) getCreateViewStatement(view string) (string, error) {
+	s := fmt.Sprintf("\n--\n-- Definition for view `%s`\n--\n\n", view)
+	row := d.useTransactionOrDBQueryRow(fmt.Sprintf("SHOW CREATE VIEW `%s`", view))
+	var vname, ddl string
+	if err := row.Scan(&vname, &ddl); err != nil {
+		return "", err
+	}
+
+	if d.skipDefiner {
+		ddl = skipDefinerRegExp.ReplaceAllString(ddl, "")
+	}
+
 	s += fmt.Sprintf("%s;\n", ddl)
 	return s, nil
 }

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -53,7 +53,8 @@ func TestMySQLGetTables(t *testing.T) {
 	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
 		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
 			AddRow("table1", "BASE TABLE").
-			AddRow("table2", "BASE TABLE"),
+			AddRow("table2", "BASE TABLE").
+			AddRow("view3", "VIEW"),
 	)
 	tables, err := dumper.getTables()
 	assert.Equal(t, []string{"table1", "table2"}, tables)
@@ -108,6 +109,67 @@ func TestMySQLDumpCreateTableHandlingErrorWhenScanningRows(t *testing.T) {
 	)
 
 	_, err := dumper.getCreateTableStatement("table")
+	assert.NotNil(t, err)
+}
+
+func TestMySQLGetViews(t *testing.T) {
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db, nil)
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("table1", "BASE TABLE").
+			AddRow("table2", "BASE TABLE").
+			AddRow("view3", "VIEW"),
+	)
+	views, err := dumper.getViews()
+	assert.Equal(t, []string{"view3"}, views)
+	assert.Nil(t, err)
+}
+
+func TestMySQLGetTablesHandlingErrorWhenListingViews(t *testing.T) {
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db, nil)
+	expectedErr := errors.New("broken")
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnError(expectedErr)
+	tables, err := dumper.getViews()
+	assert.Equal(t, []string{}, tables)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestMySQLGetViewsHandlingErrorWhenScanningRow(t *testing.T) {
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db, nil)
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).AddRow(1, nil),
+	)
+	views, err := dumper.getViews()
+	assert.Equal(t, []string{}, views)
+	assert.NotNil(t, err)
+}
+
+func TestMySQLDumpCreateView(t *testing.T) {
+	var ddl = "CREATE DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `view` (`id`, `name`)" +
+		"AS SELECT `table`.`id` AS `id`, `table`.`name` AS `name` FROM `table`;"
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db, nil)
+	mock.ExpectQuery("SHOW CREATE VIEW `view`").WillReturnRows(
+		sqlmock.NewRows([]string{"View", "Create View"}).
+			AddRow("view", ddl),
+	)
+	str, err := dumper.getCreateViewStatement("view")
+
+	assert.Nil(t, err)
+	assert.Contains(t, str, ddl)
+}
+
+func TestMySQLDumpCreateViewHandlingErrorWhenScanningRows(t *testing.T) {
+	db, mock := getDB(t)
+	dumper := getInternalMySQLInstance(db, nil)
+	mock.ExpectQuery("SHOW CREATE VIEW `view`").WillReturnRows(
+		sqlmock.NewRows([]string{"View", "Create View"}).AddRow("view", nil),
+	)
+
+	_, err := dumper.getCreateViewStatement("view")
 	assert.NotNil(t, err)
 }
 
@@ -508,6 +570,11 @@ func Test_mySQL_ignoresTable(t *testing.T) {
 			AddRow("OLD_table", "BASE TABLE"),
 	)
 
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("OLD_table", "BASE TABLE"),
+	)
+
 	dumper := getInternalMySQLInstance(db, nil)
 
 	dumper.SetFilterMap([]string{}, []string{"OLD_table"})
@@ -570,6 +637,44 @@ func Test_mySQL_dumpsTriggers(t *testing.T) {
 	}
 }
 
+func Test_mySQL_dumpsViews(t *testing.T) {
+	db, mock := getDB(t)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", "VIEW"),
+	)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", "VIEW"),
+	)
+
+	var ddl = "CREATE DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `view` (`id`, `name`) " +
+		"AS SELECT `table`.`id` AS `id`, `table`.`name` AS `name` FROM `table`;"
+
+	mock.ExpectQuery("SHOW CREATE VIEW `view`").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", ddl),
+	)
+
+	dumper := getInternalMySQLInstance(db, nil)
+
+	dumper.dumpViews = true
+
+	b := new(strings.Builder)
+
+	err := dumper.Dump(b)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !strings.Contains(b.String(), "CREATE DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `view` (`id`, `name`) AS SELECT `table`.`id` AS `id`, `table`.`name` AS `name` FROM `table`;") {
+		t.Error("Trigger not dumped")
+	}
+}
+
 func Test_mySQL_dumpsTriggersIgnoresDefiners(t *testing.T) {
 	db, mock := getDB(t)
 
@@ -604,5 +709,44 @@ func Test_mySQL_dumpsTriggersIgnoresDefiners(t *testing.T) {
 
 	if !strings.Contains(b.String(), "CREATE TRIGGER `ins_sum` BEFORE INSERT ON `account` FOR EACH ROW SET @sum = @sum + NEW.amount;") {
 		t.Error("Trigger not dumped")
+	}
+}
+
+func Test_mySQL_dumpsViewsIgnoresDefiners(t *testing.T) {
+	db, mock := getDB(t)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", "VIEW"),
+	)
+
+	mock.ExpectQuery("SHOW FULL TABLES").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", "VIEW"),
+	)
+
+	var ddl = "CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`%` SQL SECURITY DEFINER VIEW `view` (`id`, `name`) " +
+		"AS SELECT `table`.`id` AS `id`, `table`.`name` AS `name` FROM `table`;"
+
+	mock.ExpectQuery("SHOW CREATE VIEW `view`").WillReturnRows(
+		sqlmock.NewRows([]string{"Tables_in_database", "Table_type"}).
+			AddRow("view", ddl),
+	)
+
+	dumper := getInternalMySQLInstance(db, nil)
+
+	dumper.dumpViews = true
+	dumper.skipDefiner = true
+
+	b := new(strings.Builder)
+
+	err := dumper.Dump(b)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !strings.Contains(b.String(), "CREATE ALGORITHM=UNDEFINED SQL SECURITY DEFINER VIEW `view` (`id`, `name`) AS SELECT `table`.`id` AS `id`, `table`.`name` AS `name` FROM `table`") {
+		t.Error("View not dumped")
 	}
 }

--- a/database/option.go
+++ b/database/option.go
@@ -31,6 +31,8 @@ func parseMysqlOptions(m *mySQL, options []Option) error {
 			m.ignoreGenerated = true
 		case "dump-trigger":
 			m.dumpTrigger = true
+		case "dump-views":
+			m.dumpViews = true
 		case "skip-definer":
 			m.skipDefiner = true
 		case "insert-into-limit":


### PR DESCRIPTION
Shopware CLI uses this to generate dumps https://github.com/shopware/shopware-cli/blob/62306c32935b4f72e1ce575a2cd58afee4988b97/cmd/project/project_dump.go but the dump is not helpful, when it does not contain views although they behave very similar to tables, so I duplicated parts for tables and made it match view handling.

Please review and test for yourself.